### PR TITLE
Fix the broken web link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Remark: This website is only used for collecting and grouping the related paper. If there are any paper need to be updated, you can contribute PR.
 We also welcome contributions of summaries of scientific papers based on large language models, such as [chatgpt_academic](https://github.com/binary-husky/chatgpt_academic) and [ChatPaper](https://github.com/kaixindelele/ChatPaper).
 
-Please check the web [wcventure.github.io/FuzzingPaper](wcventure.github.io/FuzzingPaper), as the `.md` file shown in Github is cropped.
+Please check the web [wcventure.github.io/FuzzingPaper](https://wcventure.github.io/FuzzingPaper/), as the `.md` file shown in Github is cropped.
 
 ## Contributors
 


### PR DESCRIPTION
Fix that the web link https://wcventure.github.io/FuzzingPaper/ in README.md does not  link to the webpage.