### PR TITLE
add OOPSLA fuzzing papers from 2022 to 2024 as the original repo misses this par

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![Star History Chart](https://api.star-history.com/svg?repos=wcventure/FuzzingPaper&type=Date)](https://star-history.com/#wcventure/FuzzingPaper&Date)
 
 # All Papers (Classification according to Publication)
+- 
 - **ESEC/FSE 2024**
   - [BRF: Fuzzing the eBPF runtime](https://arxiv.org/abs/2305.08782)
   - [Evaluating Directed Fuzzers: Are We Heading in the Right Direction?](https://softsec.kaist.ac.kr/~sangkilc/papers/kim-fse24.pdf)
@@ -76,7 +77,9 @@
   - [Fuzzing BusyBox: Leveraging LLM and Crash Reuse for Embedded Bug Unearthing](https://www.usenix.org/conference/usenixsecurity24/presentation/asmita)
   - [From One Thousand Pages of Specification to Unveiling Hidden Bugs: Large Language Model Assisted Fuzzing of Matter IoT Devices](https://www.usenix.org/conference/usenixsecurity24/presentation/ma-xiaoyue)
 - **ASPLOS 2024**
-  - [Greybox Fuzzing for Concurrency Testing]
+  - [Greybox Fuzzing for Concurrency Testing](https://dl.acm.org/doi/abs/10.1145/3620665.3640389)
+- **OOPSLA 2024**
+  - [WhiteFox: White-box Compiler Fuzzing Empowered by Large Language Models](https://arxiv.org/abs/2310.15991)
 - **Others 2024**
   - [Crash Report Accumulation During Continuous Fuzzing with CASR (IVMEM 2024)](https://arxiv.org/abs/2405.18174)
 - **MobiSys 2023**
@@ -87,6 +90,9 @@
   - [LFuzz: Exploiting Locality-Enabled Techniques for File-System Fuzzing](https://link.springer.com/chapter/10.1007/978-3-031-51476-0_25)
   - [SPLITS: Split Input-to-State Mapping for Effective Firmware Fuzzing](https://link.springer.com/chapter/10.1007/978-3-031-51482-1_15)
   - [Forkfuzz: Leveraging the Fork-Awareness in Coverage-Guided Fuzzing](https://link.springer.com/chapter/10.1007/978-3-031-54129-2_17)
+- **OOPSLA 2023**
+  - [Accelerating Fuzzing through Prefix-Guided Execution](https://dl.acm.org/doi/10.1145/3586027)
+  - [Towards Better Semantics Exploration for Browser Fuzzing](https://dl.acm.org/doi/10.1145/3622819)
 - **PLDI 2023**
   - [Fuzzing Loop Optimizations in Compilers for C++ and Data-Parallel Languages](https://pldi23.sigplan.org/details/pldi-2023-pldi/76/Fuzzing-Loop-Optimizations-in-Compilers-for-C-and-Data-Parallel-Languages)
   - [WasmRef-Isabelle: a Verified Monadic Interpreter and Industrial Fuzzing Oracle for WebAssembly](https://pldi23.sigplan.org/details/pldi-2023-pldi/5/WasmRef-Isabelle-A-Verified-Monadic-Interpreter-and-Industrial-Fuzzing-Oracle-for-We)
@@ -170,6 +176,8 @@
   - [Rainfuzz: Reinforcement-Learning Driven Heat-Maps for Boosting Coverage-Guided Fuzzing](#rainfuzz-reinforcement-learning-driven-heat-maps-for-boosting-coverage-guided-fuzzing-icpram-2023)
   - [SWaTEval: An Evaluation Framework for Stateful Web Application Testing](#swateval-an-evaluation-framework-for-stateful-web-application-testing-icissp-2023)
   - [Evaluating the Fork-Awareness of Coverage-Guided Fuzzers](#evaluating-the-fork-awareness-of-coverage-guided-fuzzers-icissp-2023)
+- **OOPSLA 2022**
+  - [Satisfiability Modulo Fuzzing: A Synergistic Combination of SMT Solving and Fuzzing](https://dl.acm.org/doi/10.1145/3563332)
 - **ASE 2022**
   - [Effectively Generating Vulnerable Transaction Sequences in Smart Contracts with Reinforcement Learning-guided Fuzzing](https://dl.acm.org/doi/10.1145/3551349.3560429)
   - [Efficient Greybox Fuzzing to Detect Memory Errors](https://dl.acm.org/doi/10.1145/3551349.3561161)
@@ -234,7 +242,7 @@
   - [FIXREVERTER: A Realistic Bug Injection Methodology for Benchmarking Fuzz Testing](#fixreverter-a-realistic-bug-injection-methodology-for-benchmarking-fuzz-testing-usenix-sec22)
   - [StateFuzz: System Call-Based State-Aware Linux Driver Fuzzing](#statefuzz-system-call-based-state-aware-linux-driver-fuzzing-usenix-sec-2022)
 - **ICSE 2022**
-  - [��AFL: Non-intrusive Feedback-driven Fuzzing for Microcontroller Firmware](#��afl-non-intrusive-feedback-driven-fuzzing-for-microcontroller-firmware-icse-2022)
+  - [μAFL: Non-intrusive Feedback-driven Fuzzing for Microcontroller Firmware](μafl-non-intrusive-feedback-driven-fuzzing-for-microcontroller-firmware-icse-2022)
   - [BeDivFuzz: Integrating Behavioral Diversity into Generator-based Fuzzing](#bedivfuzz-integrating-behavioral-diversity-into-generator-based-fuzzing-icse-2022)
   - [CONFETTI: Amplifying Concolic Guidance for Fuzzers](#confetti-amplifying-concolic-guidance-for-fuzzers-icse-2022)
   - [Demystifying the Dependency Challenge in Kernel Fuzzing](#demystifying-the-dependency-challenge-in-kernel-fuzzing-icse-2022)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 [![Star History Chart](https://api.star-history.com/svg?repos=wcventure/FuzzingPaper&type=Date)](https://star-history.com/#wcventure/FuzzingPaper&Date)
 
 # All Papers (Classification according to Publication)
-- 
 - **ESEC/FSE 2024**
   - [BRF: Fuzzing the eBPF runtime](https://arxiv.org/abs/2305.08782)
   - [Evaluating Directed Fuzzers: Are We Heading in the Right Direction?](https://softsec.kaist.ac.kr/~sangkilc/papers/kim-fse24.pdf)


### PR DESCRIPTION
This PR adds OOPSLA fuzzing papers from 2022 to 2024 as the original repo misses this part.

BTW, fix some typos.