### PR TITLE
Add an omitted fuzz testing paper from ICSE 2023 : Testing Database Engines via Query Plan Guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@
   - [Regression Fuzzing for Deep Learning Systems](https://ieeexplore.ieee.org/document/10172506/)
   - [Large Language Models are Few-shot Testers: Exploring LLM-based General Bug Reproduction](#large-language-models-are-few-shot-testers-exploring-llm-based-general-bug-reproduction-icse-2023)
   - [Validating SMT Solvers via Skeleton Enumeration Empowered by Historical Bug-Triggering Inputs](#validating-smt-solvers-via-skeleton-enumeration-empowered-by-historical-bug-triggering-inputs-icse-2023)
+  - [Testing Database Engines via Query Plan Guidance](https://dl.acm.org/doi/10.1109/ICSE48619.2023.00174)
 - **NDSS 2023**
   - [Assessing the Impact of Interface Vulnerabilities in Compartmentalized Software](#assessing-the-impact-of-interface-vulnerabilities-in-compartmentalized-software-ndss-2023)
   - [FUZZILLI: Fuzzing for JavaScript JIT Compiler Vulnerabilities](#fuzzilli-fuzzing-for-javascript-jit-compiler-vulnerabilities-ndss-2023)


### PR DESCRIPTION
_Testing Database Engines via Query Plan Guidance_
This paper uses Query Plan Guidance to direct database fuzz testing.
In the experimental comparison section, the paper integrates Query Plan Guidance into database fuzz testing tools SQLancer and SQLRight, demonstrating outstanding performance. This provides new ideas and methods for guiding database fuzz testing.
It is possible that the paper was not included in the ICSE 2023 paper list because its title and abstract did not explicitly indicate its relevance to fuzz testing.